### PR TITLE
Changing MM relationships of Sigma Replacements: Navigation patch

### DIFF
--- a/GameData/GPP/GPP_Replacements/Configs/NavBall.cfg
+++ b/GameData/GPP/GPP_Replacements/Configs/NavBall.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[SigmaReplacementsNavigation]:FINAL
+@PART:HAS[@MODULE[ModuleCommand],~SigmaNavBall[false]]:NEEDS[SigmaReplacementsNavigation]:FINAL
 {
     MODULE
     {
@@ -6,20 +6,20 @@
         NavBall
         {
             NavBallTex = GPP/GPP_Replacements/Navigation/navball
-			IVAemissiveTex = GPP/GPP_Replacements/Navigation/navball2
+            IVAemissiveTex = GPP/GPP_Replacements/Navigation/navball2
             ShadingTex = GPP/GPP_Replacements/Navigation/glass
-            Cursor = 1,1,1,1
+            Cursor = 1, 1, 1, 1
         }
     }
 }
 @SigmaReplacements:FOR[GPP]
 {
-	Kerbal
-	{
-		NavBall
-		{
-			NavBallTex = GPP/GPP_Replacements/Navigation/navball
+    Kerbal
+    {
+        NavBall
+        {
+            NavBallTex = GPP/GPP_Replacements/Navigation/navball
             ShadingTex = GPP/GPP_Replacements/Navigation/glass
-		}
-	}
+        }
+    }
 }

--- a/GameData/GPP/GPP_Replacements/Configs/NavBall.cfg
+++ b/GameData/GPP/GPP_Replacements/Configs/NavBall.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleCommand]]:FOR[GPP]
+@PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[SigmaReplacementsNavigation]:FINAL
 {
     MODULE
     {


### PR DESCRIPTION
The first patch still tries to run even if Sigma Replacements: Navigation is not installed and throws an error in this case.

I'd recommend changing the patch to only run if SR:N is installed but also require the patch to run at the end of the patching order so that it is also applied to any additional mod parts that the user may be using.