### PR TITLE
Fixed black sky bug with scatterer.

### DIFF
--- a/GameData/GPP/GPP_Scatterer/Planets/Gael/atmo.cfg
+++ b/GameData/GPP/GPP_Scatterer/Planets/Gael/atmo.cfg
@@ -31,7 +31,7 @@
 			Item
 			{
 				altitude = 200
-				skyExposure = 0
+				skyExposure = 0.25
 				skyAlpha = 0.90
 				skyExtinctionTint = 1
 				scatteringExposure = 0.2
@@ -45,7 +45,7 @@
 			Item
 			{
 				altitude = 1000
-				skyExposure = 0
+				skyExposure = 0.25
 				skyAlpha = 0.90
 				skyExtinctionTint = 1
 				scatteringExposure = 0.2
@@ -59,7 +59,7 @@
 			Item
 			{
 				altitude = 5000
-				skyExposure = 0
+				skyExposure = 0.2
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.23
@@ -73,7 +73,7 @@
 			Item
 			{
 				altitude = 55000
-				skyExposure = 0
+				skyExposure = 0.13
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.23
@@ -134,7 +134,7 @@ Scatterer_atmosphere:NEEDS[GPP_Secondary]
 			Item
 			{
 				altitude = 200
-				skyExposure = 0
+				skyExposure = 0.25
 				skyAlpha = 0.90
 				skyExtinctionTint = 1
 				scatteringExposure = 0.2
@@ -148,7 +148,7 @@ Scatterer_atmosphere:NEEDS[GPP_Secondary]
 			Item
 			{
 				altitude = 1000
-				skyExposure = 0
+				skyExposure = 0.25
 				skyAlpha = 0.90
 				skyExtinctionTint = 1
 				scatteringExposure = 0.2
@@ -162,7 +162,7 @@ Scatterer_atmosphere:NEEDS[GPP_Secondary]
 			Item
 			{
 				altitude = 5000
-				skyExposure = 0
+				skyExposure = 0.2
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.23
@@ -176,7 +176,7 @@ Scatterer_atmosphere:NEEDS[GPP_Secondary]
 			Item
 			{
 				altitude = 55000
-				skyExposure = 0
+				skyExposure = 0.13
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.23

--- a/GameData/GPP/GPP_Scatterer/Planets/Tellumo/atmo.cfg
+++ b/GameData/GPP/GPP_Scatterer/Planets/Tellumo/atmo.cfg
@@ -30,7 +30,7 @@ Scatterer_atmosphere
 			Item
 			{
 				altitude = 200
-				skyExposure = 0
+				skyExposure = 0.25
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.2
@@ -44,7 +44,7 @@ Scatterer_atmosphere
 			Item
 			{
 				altitude = 1000
-				skyExposure = 0
+				skyExposure = 0.25
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.2
@@ -58,7 +58,7 @@ Scatterer_atmosphere
 			Item
 			{
 				altitude = 5000
-				skyExposure = 0
+				skyExposure = 0.2
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.23
@@ -72,7 +72,7 @@ Scatterer_atmosphere
 			Item
 			{
 				altitude = 55000
-				skyExposure = 0
+				skyExposure = 0.13
 				skyAlpha = 0.9
 				skyExtinctionTint = 1
 				scatteringExposure = 0.23


### PR DESCRIPTION
Scatterer skyExposure values were previously zero for Gael and Tellumo, causing the atmosphere to appear black. Now there are proper nonzero values that were taken from skyRimExposure fields in old scatterer configs.