### PR TITLE
Thinned atmospheric scattering

### DIFF
--- a/GameData/GPP/GPP_Scatterer/Planets/Augustus/atmo.cfg
+++ b/GameData/GPP/GPP_Scatterer/Planets/Augustus/atmo.cfg
@@ -75,7 +75,7 @@ Scatterer_atmosphere
 				skyExposure = 0.1
 				skyAlpha = 1
 				skyExtinctionTint = -0.3
-				scatteringExposure = 0.23
+				scatteringExposure = 0.08
 				extinctionThickness = 1
 				postProcessAlpha = 0.4
 				postProcessDepth = 2.4

--- a/GameData/GPP/GPP_Scatterer/Planets/Tarsiss/atmo.cfg
+++ b/GameData/GPP/GPP_Scatterer/Planets/Tarsiss/atmo.cfg
@@ -75,7 +75,7 @@ Scatterer_atmosphere
 				skyExposure = 0.1
 				skyAlpha = 0.5
 				skyExtinctionTint = -0.3
-				scatteringExposure = 0.23
+				scatteringExposure = 0.03
 				extinctionThickness = 1
 				postProcessAlpha = 0.5
 				postProcessDepth = 2.4


### PR DESCRIPTION
Tarsiss atmosphere appeared too white in relation to its wiki depiction. (KSP 1.7.3, Scatterer 0.0540)
![screenshot338](https://user-images.githubusercontent.com/56806370/85915192-682eac00-b813-11ea-8bf6-57e5b98b2786.png)
![screenshot339](https://user-images.githubusercontent.com/56806370/85915194-6c5ac980-b813-11ea-99b5-797b3b8fbeaa.png)

