### PR TITLE
Add missing dependency

### DIFF
--- a/CKAN/GPPSecondary.netkan
+++ b/CKAN/GPPSecondary.netkan
@@ -10,6 +10,9 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
     },
+    "depends": [
+        { "name": "Kopernicus" }
+    ],
     "$vref": "#/ckan/ksp-avc",
     "ksp_version": "1.4.5",
     "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",


### PR DESCRIPTION
GPP Secondary currently doesn't depend on Kopernicus. Apparently this is wrong:

![image](https://user-images.githubusercontent.com/1559108/86214790-3eda8c80-bb41-11ea-86f9-778df5f43e86.png)

Now it does.