### PR TITLE
Split out Grannus ribbons

### DIFF
--- a/CKAN/GPP.netkan
+++ b/CKAN/GPP.netkan
@@ -19,6 +19,7 @@
         {
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
+            "filter": [ "Grannus" ],
             "comment": "This correctly installs Final Frontier for GPP"
         }
     ],
@@ -69,6 +70,9 @@
         },
         {
             "name": "SigmaReplacements-MenuScenes"
+        },
+        {
+            "name": "Grannus-RibbonPack"
         }
     ],
     "suggests": [


### PR DESCRIPTION
See KSP-CKAN/NetKAN#8024, the Grannus ribbons are causing a conflict with GEP. After that PR is merged, the ribbons will be provided by separate modules so GPP and GEP can be installed at the same time.

FYI to @OhioBob.