### PR TITLE
Fix KSP version compatibility in netkan files

### DIFF
--- a/CKAN/GPP.netkan
+++ b/CKAN/GPP.netkan
@@ -14,6 +14,7 @@
         {
             "find": "GPP",
             "install_to": "GameData",
+            "filter": [ "Grannus" ],
             "comment": "This is the main install for GPP"
         },
         {
@@ -68,6 +69,9 @@
         },
         {
             "name": "SigmaReplacements-MenuScenes"
+        },
+        {
+            "name": "Grannus-RibbonPack"
         }
     ],
     "suggests": [

--- a/CKAN/GPP.netkan
+++ b/CKAN/GPP.netkan
@@ -22,7 +22,6 @@
             "comment": "This correctly installs Final Frontier for GPP"
         }
     ],
-    "ksp_version": "1.4.5",
     "depends": [
         {
             "name": "ModuleManager"

--- a/CKAN/GPPCloudsHighRes.netkan
+++ b/CKAN/GPPCloudsHighRes.netkan
@@ -1,33 +1,31 @@
 {
     "spec_version": "v1.4",
-    "install": [
-        {
-            "find": "Optional Mods/GPP_Clouds/High-res Clouds_GameData inside/GameData/GPP",
-            "install_to": "GameData",
-            "comment": "This installs the high resolution clouds configs for GPP"
-        }
-    ],
+    "identifier": "GPPCloudsHighRes",
+    "name": "GPP HighRes clouds",
+    "abstract": "High resolution clouds for GPP",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
     },
-    "depends": [
-        {
-            "name": "EnvironmentalVisualEnhancements"
-        }
-    ],
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
+    ],
+    "depends": [
+        { "name": "EnvironmentalVisualEnhancements" },
+        { "name": "GPP"                             }
     ],
     "conflicts": [
         {
             "name": "GPPCloudsLowRes"
         }
     ],
-    "$vref": "#/ckan/ksp-avc",
-    "ksp_version": "1.4.5",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
-    "identifier": "GPPCloudsHighRes",
-    "name": "GPP HighRes clouds",
-    "abstract": "High resolution clouds for GPP",
-    "license": "CC-BY-NC-ND"
+    "install": [
+        {
+            "find": "Optional Mods/GPP_Clouds/High-res Clouds_GameData inside/GameData/GPP",
+            "install_to": "GameData",
+            "comment": "This installs the high resolution clouds configs for GPP"
+        }
+    ]
 }

--- a/CKAN/GPPCloudsLowRes.netkan
+++ b/CKAN/GPPCloudsLowRes.netkan
@@ -1,33 +1,31 @@
 {
     "spec_version": "v1.4",
-    "install": [
-        {
-            "find": "Optional Mods/GPP_Clouds/Low-res Clouds_GameData inside/GameData/GPP",
-            "install_to": "GameData",
-            "comment": "This installs the low resolution clouds configs for GPP"
-        }
-    ],
+    "identifier": "GPPCloudsLowRes",
+    "name": "GPP LowRes clouds",
+    "abstract": "Low resolution clouds for GPP",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
     },
-    "depends": [
-        {
-            "name": "EnvironmentalVisualEnhancements"
-        }
-    ],
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
+    ],
+    "depends": [
+        { "name": "EnvironmentalVisualEnhancements" },
+        { "name": "GPP"                             }
     ],
     "conflicts": [
         {
             "name": "GPPCloudsHighRes"
         }
     ],
-    "$vref": "#/ckan/ksp-avc",
-    "ksp_version": "1.4.5",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
-    "identifier": "GPPCloudsLowRes",
-    "name": "GPP LowRes clouds",
-    "abstract": "Low resolution clouds for GPP",
-    "license": "CC-BY-NC-ND"
+    "install": [
+        {
+            "find": "Optional Mods/GPP_Clouds/Low-res Clouds_GameData inside/GameData/GPP",
+            "install_to": "GameData",
+            "comment": "This installs the low resolution clouds configs for GPP"
+        }
+    ]
 }

--- a/CKAN/GPPSecondary.netkan
+++ b/CKAN/GPPSecondary.netkan
@@ -1,5 +1,14 @@
 {
     "spec_version": "v1.4",
+    "identifier": "GPPSecondary",
+    "name": "GPP Secondary",
+    "abstract": "GPP secondary puts Galileo's Planet Pack around the stock solar system.",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
+    },
     "install": [
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
@@ -7,17 +16,8 @@
             "comment": "This installs the GPP_Secondary configs for GPP"
         }
     ],
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
-    },
     "depends": [
-        { "name": "Kopernicus" }
-    ],
-    "$vref": "#/ckan/ksp-avc",
-    "ksp_version": "1.4.5",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
-    "identifier": "GPPSecondary",
-    "name": "GPP Secondary",
-    "abstract": "GPP secondary puts Galileo's Planet Pack around the stock solar system.",
-    "license": "CC-BY-NC-ND"
+        { "name": "Kopernicus" },
+        { "name": "GPP"        }
+    ]
 }

--- a/CKAN/GPPTextures.netkan
+++ b/CKAN/GPPTextures.netkan
@@ -1,21 +1,23 @@
 {
     "spec_version": "v1.4",
+    "identifier": "GPPTextures",
+    "name": "GPP Textures",
+    "abstract": "Textures for Galileo's Planet Pack.",
+    "author": "Galileo88",
+    "license": "CC-BY-NC-ND",
+    "version": "4.2.1",
+    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/4.2.1/GPP_Textures-4.2.1.zip",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
+    },
+    "depends": [
+        { "name": "GPP" }
+    ],
     "install": [
         {
             "find": "GPP",
             "install_to": "GameData",
             "comment": "This correctly installs the textures for GPP"
         }
-    ],
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
-    },
-    "version": "4.2.1",
-    "ksp_version": "1.4.5",
-    "author": "Galileo88",
-    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/4.2.1/GPP_Textures-4.2.1.zip",
-    "identifier": "GPPTextures",
-    "name": "GPP Textures",
-    "abstract": "Textures for Galileo's Planet Pack.",
-    "license": "CC-BY-NC-ND"
+    ]
 }

--- a/GameData/GPP/Version/GalileosPlanetPack.version
+++ b/GameData/GPP/Version/GalileosPlanetPack.version
@@ -9,14 +9,14 @@
         "PATCH":5,
         "BUILD":0
     },
-    "KSP_VERSION":{
-        "MAJOR":1,
-        "MINOR":8,
-        "PATCH":1
-    },
     "KSP_VERSION_MIN":{
         "MAJOR":1,
         "MINOR":8,
         "PATCH":1
     },
+    "KSP_VERSION_MAX":{
+        "MAJOR":1,
+        "MINOR":11,
+        "PATCH":1
+    }
 }


### PR DESCRIPTION
## Problem
The version overview for GPP, GPPCloudsHighRes, GPPCloudsLowRes and GPPSecondary in CKAN currently looks like this:
![](https://cdn.discordapp.com/attachments/601455398553387008/818659559018856488/unknown.png)
while the forum thread says this:
![image](https://user-images.githubusercontent.com/28812678/110410908-ee311100-8089-11eb-87c4-4e65616b5a28.png)

GPPTextures doesn't look much better.

## Changes
The hardcoded compatibilities in all netkan files are removed. That's what the AVC .version file included in the download (and its online copy in the repo) is for, which CKAN will use as source of compatibility data from now on.

The .version file got a new `KSP_VERSION_MAX` to make sure the releases don't have unbounded future compatibility. This means a tiny bit of extra maintenance to update the maximum compatibility when new KSP versions drop, but gives an extra safeguard to avoid users installing it even if it is broken for the new release.
Preemptive info: No new release is required after the version file in the repository got updated for a new KSP release, since the `URL` property of the file included in the zip points to the remote file, CKAN will detect the change and update the metadata accordingly.

The zip for GPPTextures doesn't have a version file, so it's now unbounded, which shouldn't be much of a problem since it is dependent on GPP anyway.

To reflect this in CKAN, GPP is added to the dependencies of GPPTextures, as well as GPPCloudsHighRes, GPPCloudsLowRes and GPPSecondary.

The changes from #64 are incorporated as well.

Pinging @Galileo88 @OhioBob to make sure the notifications arrive.
@HebaruSan FYI

Closes #64