### PR TITLE
Avoid double Strategia patching with JNSQ

### DIFF
--- a/GameData/GPP/GPP_Configs/GPP_Strategia.cfg
+++ b/GameData/GPP/GPP_Configs/GPP_Strategia.cfg
@@ -1,5 +1,5 @@
 // Authors: Nightingale, Galileo
-STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = MoonProgram
@@ -113,7 +113,7 @@ STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
         body = $body
     }
 }
-STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = PlanetaryProgram
@@ -266,7 +266,7 @@ STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
         body = $body
     }
 }
-STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = GasGiantProgram
@@ -367,7 +367,7 @@ STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
         body = @bodies
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = AstronautTrainingProgram
@@ -427,7 +427,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         AffectReasons = CrewRecruited
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = MassiveLaunches
@@ -528,7 +528,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         AffectReasons = StructureRepair
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = Standards
@@ -582,7 +582,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         AffectReason = ContractReward
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = PilotFocus
@@ -661,7 +661,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         trait = Pilot
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = EngineerFocus
@@ -755,7 +755,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         trait = Engineer
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = ScientistFocus
@@ -836,7 +836,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         trait = Scientist
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = PrivateIndustry
@@ -901,7 +901,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
       AffectReasons = VesselRollout
   }
 }
-STRATEGY:NEEDS[Strategia&CustomBarnKit]
+STRATEGY:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = PublicSpectating
@@ -951,7 +951,7 @@ STRATEGY:NEEDS[Strategia&CustomBarnKit]
 	AffectReasons = Progression
   }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = MediaCoverage
@@ -1061,7 +1061,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         minLevel = 3
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = BoldlyGo
@@ -1125,7 +1125,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         excludeBody = $homeWorld
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = ProbeFrenzy
@@ -1219,7 +1219,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         AffectReason = Progression
     }
 }
-STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = LocalScience
@@ -1275,7 +1275,7 @@ STRATEGY_LEVEL_EXPAND:NEEDS[Strategia&CustomBarnKit]
         AffectReasons = RnDTechResearch
     }
 }
-STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = MoonProgram
@@ -1385,7 +1385,7 @@ STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
         body = $body
     }
 }
-STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
+STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = PlanetaryProgram
@@ -1533,7 +1533,7 @@ STRATEGY_BODY_EXPAND:NEEDS[Strategia&CustomBarnKit]
         body = $body
     }
 }
-STRATEGY:NEEDS[Strategia&CustomBarnKit]
+STRATEGY:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = ImpactorProbes
@@ -1589,7 +1589,7 @@ STRATEGY:NEEDS[Strategia&CustomBarnKit]
         id = ImpactorProbes
     }
 }
-STRATEGY:NEEDS[Strategia&CustomBarnKit]
+STRATEGY:NEEDS[Strategia&CustomBarnKit,!JNSQ]
 {
     author = Galileo
     name = FlyByProbes


### PR DESCRIPTION
When Strategia and JNSQ are also installed, do not apply GameData\GPP\GPP_Configs\GPP_Strategia.cfg to avoid having all programs for celestial bodies twice.